### PR TITLE
Fix for gnome shell 3.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,45 @@
 # nm-hide-unmanaged
 
-This is simple gnome shell extension that hide all unmanaged network devices from gnome status applet (and also an example of monkey patching in gnome shell).
-This is very usefull when using a lot of virtual solutions, such as docker or virtual box, that creates many network devices.
+This is simple gnome shell extension that hides all unmanaged network devices from the gnome status applet (and also an example of monkey patching in gnome shell).
+This is very useful when using a lot of virtual solutions such as VMware, docker, virtual box or other applications which create many network devices.
 
-To install just place this extension into `~/.local/share/gnome-shell/extensions/` folder and relogin. 
-Use `gnome-tweak-tool` to enable the extension.
+## Install
 
-This is example of my `/etc/NetworkManager/NetworkManager.conf`:
+To install the extension either clone or download this project and rename the folder to `nm-hide-unmanaged@linniksa.gmail.com`.
+Move the `nm-hide-unmanaged@linniksa.gmail.com` folder into `~/.local/share/gnome-shell/extensions/` and then restart gnome shell, logout and back in or restart your computer. After restarting enable the extension in the `gnome-tweak-tool`.
+
+**It is very important that the folder name is exactly the same as `nm-hide-unmanaged@linniksa.gmail.com`. If the names do not match, the extension will not load properly.**
+
+## Network config
+
+This extension only hides **unmanaged** network devices. To hide unwanted network devices mark them as unmanaged in the NetworkManager config. This config can be found at `/etc/NetworkManager/NetworkManager.conf`.
+To mark a network device as unmanaged add either the interface name or mac address in the config as indicated below.
+```
+[keyfile]
+unmanaged-devices=interface-name:vmnet1,interface-name:vmnet8,mac:00:19:e0:57:86:af
+```
+
+Wild cards are also allowed
+
+```
+[keyfile]
+unmanaged-devices=interface-name:vmnet*,mac:00:19:e0:57:86:*
+```
+
+This is example of a complete `/etc/NetworkManager/NetworkManager.conf`:
 ```
 [main]
 plugins=keyfile
 
 [keyfile]
-unmanaged-devices=interface-name:vmnet*,interface-name:docker*,interface-name:br-*,interface-name:veth*,interface-name:virbr*
+# VMWare
+unmanaged-devices=interface-name:vmnet*
 
+# Virtualbox
+unmanaged-devices=interface-name:vboxnet*
+
+# Docker
+unmanaged-devices=interface-name:docker*
 ```
 
 Don't forget to `reboot` to apply all changes

--- a/extension.js
+++ b/extension.js
@@ -11,7 +11,7 @@ let origDeviceAdded;
 function enable() {
     origDeviceAdded = Network.NMApplet.prototype._deviceAdded;
 
-    let f = function (client, device, skipSyncDeviceNames) {
+    let decoratedFunction = function (client, device, skipSyncDeviceNames) {
         if (device.state === NetworkManager.DeviceState.UNMANAGED) {
             return;
         }
@@ -19,7 +19,7 @@ function enable() {
         origDeviceAdded.call(this, client, device, skipSyncDeviceNames);
     };
 
-    Network.NMApplet.prototype._deviceAdded = f;
+	Network.NMApplet.prototype._deviceAdded = decoratedFunction;
 }
 
 function disable() {

--- a/extension.js
+++ b/extension.js
@@ -1,8 +1,12 @@
 
-const NetworkManager = imports.gi.NetworkManager;
+let NetworkManager = imports.gi.NetworkManager;
+if (!NetworkManager || !NetworkManager.DeviceState) {
+    NetworkManager = imports.gi.NM;
+}
 const Network = imports.ui.status.network;
 
 let origDeviceAdded;
+
 
 function enable() {
     origDeviceAdded = Network.NMApplet.prototype._deviceAdded;
@@ -15,7 +19,7 @@ function enable() {
         origDeviceAdded.call(this, client, device, skipSyncDeviceNames);
     };
 
-    Network.NMApplet.prototype._deviceAdded = Network.NMApplet.wrapFunction('_deviceAdded', f);
+    Network.NMApplet.prototype._deviceAdded = f;
 }
 
 function disable() {

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,7 @@
     "description": "This extension hides unmanaged devices from Network Manager applet.",
     "name": "Network Manager hide unmanaged",
     "shell-version": [
-        "3.22.3"
+        "3.22.3",
+        "3.32.2"
     ]
 }


### PR DESCRIPTION
Fixes the extension for newer gnome shell version.
Also makes the README more descriptive, primarily the installation steps.