### PR TITLE
Add compatibility for GNOME 40

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,6 +4,7 @@
     "name": "Network Manager hide unmanaged",
     "shell-version": [
         "3.22.3",
-        "3.32.2"
+        "3.32.2",
+        "40"
     ]
 }


### PR DESCRIPTION
The extension works pretty well with GNOME 40 as far as I have tested, so we need to extend the compatible shell version.